### PR TITLE
fix: use current fan mode

### DIFF
--- a/honeywellhomeapp.groovy
+++ b/honeywellhomeapp.groovy
@@ -1071,7 +1071,7 @@ def setThermosatFan(com.hubitat.app.DeviceWrapper device, fan=null, retry=false)
 
     if (fan == null)
     {
-        fan=device.('thermostatFanMode');
+        fan = device.currentValue('thermostatFanMode')
     }
 
     if (fan.toLowerCase() == "auto")


### PR DESCRIPTION
## Summary
- retrieve thermostat fan mode using `currentValue`

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `sh createPackageRelease.sh -v 0 -c . -r test` *(fails: hpm: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79f50a9483239c3785809659ff79