### PR TITLE
fix: use roomId consistently for remote sensor lookups

### DIFF
--- a/honeywellhomeapp.groovy
+++ b/honeywellhomeapp.groovy
@@ -824,7 +824,7 @@ String getRemoteSensorUserDefName(String parentDeviceId, String locationId, Stri
         {
             LogWarn('Authorization token expired, will refresh and retry.')
             refreshToken()
-            getRemoteSensorUserDefName(parentDeviceId, locationId, groupId, roomID, true)
+            getRemoteSensorUserDefName(parentDeviceId, locationId, groupId, roomId, true)
         }
 
         LogError("Remote Sensor API failed -- ${e.getLocalizedMessage()}: ${e.response.data}")
@@ -881,7 +881,7 @@ def refreshRemoteSensor(com.hubitat.app.DeviceWrapper device, retry=false)
     LogDebug("refreshRemoteSensor()")
     def honeywellDeviceID = device.currentValue("parentDeviceId")
     def honeywellLocation = device.currentValue("locationId")
-    def roomID = device.currentValue("roomId")
+    def roomId = device.currentValue("roomId")
     def uri = global_apiURL + '/v2/devices/thermostats/'+ honeywellDeviceID + '/priority?apikey=' + settings.consumerKey + '&locationId=' + honeywellLocation
     def headers = [ Authorization: 'Bearer ' + state.access_token ]
     def contentType = 'application/json'
@@ -929,7 +929,7 @@ def refreshRemoteSensor(com.hubitat.app.DeviceWrapper device, retry=false)
 
     def roomJson
     reJson.currentPriority.rooms.each{ room ->
-        if (room.id == roomID) {
+        if (room.id == roomId) {
             roomJson = room
             return
         }


### PR DESCRIPTION
## Summary
- ensure `getRemoteSensorUserDefName` recurses using `roomId` argument
- rename local `roomID` variables to `roomId` in remote sensor refresh

## Testing
- `./gradlew test` *(fails: No such file or directory)*
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79f4638c83238b8dd1981b51bcdc