### PR TITLE
Fix Honeywell app log string interpolation

### DIFF
--- a/honeywellhomeapp.groovy
+++ b/honeywellhomeapp.groovy
@@ -576,8 +576,8 @@ def loginResponse(response)
 
     def reCode = response.getStatus();
     def reJson = response.getData();
-    LogDebug("reCode: {$reCode}")
-    LogDebug("reJson: {$reJson}")
+    LogDebug("reCode: ${reCode}")
+    LogDebug("reJson: ${reJson}")
 
     if (reCode == 200)
     {
@@ -689,8 +689,8 @@ def refreshThermosat(com.hubitat.app.DeviceWrapper device, retry=false)
             response ->
             def reCode = response.getStatus();
             reJson = response.getData();
-            LogDebug("reCode: {$reCode}")
-            LogDebug("reJson: {$reJson}")
+            LogDebug("reCode: ${reCode}")
+            LogDebug("reJson: ${reJson}")
         }
     }
     catch (groovyx.net.http.HttpResponseException e) 
@@ -814,8 +814,8 @@ String getRemoteSensorUserDefName(String parentDeviceId, String locationId, Stri
                     response ->
                         def reCode = response.getStatus();
                         reJson = response.getData();
-                        LogDebug("reCode: {$reCode}")
-                        LogDebug("reJson: {$reJson}")
+                        LogDebug("reCode: ${reCode}")
+                        LogDebug("reJson: ${reJson}")
                 }
     }
     catch (groovyx.net.http.HttpResponseException e)
@@ -897,8 +897,8 @@ def refreshRemoteSensor(com.hubitat.app.DeviceWrapper device, retry=false)
                     response ->
                         def reCode = response.getStatus();
                         reJson = response.getData();
-                        LogDebug("reCode: {$reCode}")
-                        LogDebug("reJson: {$reJson}")
+                        LogDebug("reCode: ${reCode}")
+                        LogDebug("reJson: ${reJson}")
                 }
     }
     catch (groovyx.net.http.HttpResponseException e)


### PR DESCRIPTION
## Summary
- Replace malformed `{$var}` string interpolation in debug logs with Groovy's `${var}` syntax.
- Ensure no remaining log statements use the incorrect `{$var}` pattern.

## Testing
- `groovyc honeywellhomeapp.groovy` *(fails: unable to resolve several classes)*

------
https://chatgpt.com/codex/tasks/task_e_68ac79f3b2308323926a57ac7e74e69d