### PR TITLE
fix: refine release tag parsing

### DIFF
--- a/.github/workflows/runHpmForRelease.sh
+++ b/.github/workflows/runHpmForRelease.sh
@@ -19,12 +19,12 @@ echo "Param githubRef: $githubRef"
 echo "Param releaseTag: $releaseTag"
 
 if [[ -z "${releaseTag}" ]]; then
-  version=$(echo $githubRef | grep -Eo [0-9].[0-9].[0-9]);
-  releaseTag = $(echo $githubRef | sed 's|refs/tags/||');
+  version=$(echo $githubRef | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+');
+  releaseTag=$(echo $githubRef | sed 's|refs/tags/||');
   echo "releaseTag: $releaseTag"
-  baseCodePath="https://raw.githubusercontent.com/thecloudtaylor/hubitat-honeywellk/$releaseTag";
+  baseCodePath="https://raw.githubusercontent.com/thecloudtaylor/hubitat-honeywell/$releaseTag";
 else
-  version=$(echo $releaseTag | grep -Eo [0-9].[0-9].[0-9]);
+  version=$(echo $releaseTag | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+');
   baseCodePath="https://raw.githubusercontent.com/thecloudtaylor/hubitat-honeywell/$releaseTag";
 fi
 


### PR DESCRIPTION
## Summary
- use strict version regex and clean assignment
- point release script at correct repository URL

## Testing
- `bash runHpmForRelease.sh -g refs/tags/v0.2.6-beta1`
- `bash runHpmForRelease.sh -g refs/heads/main -r v0.2.6-beta1`

------
https://chatgpt.com/codex/tasks/task_e_68ac79f173cc8323854e93a0c11ec995